### PR TITLE
Move AI thinking indicator to Q4 title and close task modal immediately

### DIFF
--- a/components/eisenhower-matrix.tsx
+++ b/components/eisenhower-matrix.tsx
@@ -23,6 +23,7 @@ interface QuadrantProps {
   onReorderTasks: (quadrant: QuadrantType, sourceIndex: number, destinationIndex: number) => void
   onTaskClick?: (task: Task) => void
   className?: string
+  isAIThinking?: boolean
 }
 
 function Quadrant({ 
@@ -36,7 +37,8 @@ function Quadrant({
   onEditTask, 
   onReorderTasks,
   onTaskClick,
-  className
+  className,
+  isAIThinking
 }: QuadrantProps) {
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null)
   const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null)
@@ -125,8 +127,15 @@ function Quadrant({
           <QuadrantInfoTooltip quadrantId={quadrantId} />
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground/80">{tasks.length} {quadrantId === "q1" ? "tasks to do now" : quadrantId === "q2" ? "tasks to schedule" : quadrantId === "q3" ? "tasks to delegate" : "tasks to avoid"}</span>
-          {/* AI thinking indicator removed */}
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground/80">{tasks.length} {quadrantId === "q1" ? "tasks to do now" : quadrantId === "q2" ? "tasks to schedule" : quadrantId === "q3" ? "tasks to delegate" : "tasks to avoid"}</span>
+            {quadrantId === "q4" && isAIThinking && (
+              <div className="flex items-center gap-1 text-xs text-muted-foreground/80">
+                <AIThinkingIndicator isThinking={true} className="h-3 w-3" />
+                <span className="text-[10px]">Processing tasks...</span>
+              </div>
+            )}
+          </div>
         </div>
       </div>
       <div className={cn(
@@ -264,6 +273,7 @@ interface EisenhowerMatrixProps {
   onEditTask: (taskId: string, newText: string) => void
   onReorderTasks: (quadrant: QuadrantType, sourceIndex: number, destinationIndex: number) => void
   onTaskClick?: (task: Task) => void
+  isAIThinking?: boolean
 }
 
 export function EisenhowerMatrix({ 
@@ -274,7 +284,8 @@ export function EisenhowerMatrix({
   onMoveTask, 
   onEditTask,
   onReorderTasks,
-  onTaskClick 
+  onTaskClick,
+  isAIThinking
 }: EisenhowerMatrixProps) {
   // Memoize tasks by quadrant to prevent unnecessary recalculations
   const tasksByQuadrant = useMemo(() => {
@@ -355,6 +366,7 @@ export function EisenhowerMatrix({
           onReorderTasks={onReorderTasks}
           onTaskClick={onTaskClick}
           className="quadrant-not-urgent-not-important border-muted-foreground/30"
+          isAIThinking={isAIThinking}
         />
       </div>
     </div>

--- a/components/task-manager.tsx
+++ b/components/task-manager.tsx
@@ -224,13 +224,12 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
         });
       }
       
-      // Close the modal and reset states now that the task has been analyzed and moved
-      console.log('[DEBUG] Closing modal after AI analysis complete');
-      setTaskModalOpen(false);
+      // Reset AI thinking state
+      setIsAIThinking(false);
     } else {
       console.log('[DEBUG] Missing detail in aiAnalysisComplete event');
     }
-  }, [toast, setTaskModalOpen]);
+  }, [toast]);
 
   // Set up event listeners
   useEffect(() => {
@@ -286,11 +285,14 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
     console.log('[DEBUG handleAddTask] Starting task creation:', text);
     
     try {
-      // Keep modal open while AI is thinking
+      // Close modal immediately
+      setTaskModalOpen(false);
+      
+      // Set AI thinking state for Q4 indicator
       console.log('[DEBUG handleAddTask] Setting isAIThinking to true');
       setIsAIThinking(true);
       
-      // We'll keep the modal open to show the AI analysis in progress
+      // Add task and trigger AI analysis
       console.log('[DEBUG handleAddTask] Calling addTaskWithAIAnalysis');
       const { task } = await addTaskWithAIAnalysis({
         text,
@@ -306,11 +308,6 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
         throw new Error('Failed to add task');
       }
 
-      // Modal will be closed by the aiAnalysisComplete event handler
-      // after the task has been moved to its final quadrant
-      console.log('[DEBUG handleAddTask] Current AI reasoning:', aiReasoning);
-      console.log('[DEBUG handleAddTask] Current target quadrant:', targetQuadrant);
-
       // Show success message
       toast({
         description: 'Task added successfully',
@@ -323,8 +320,6 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
         description: error instanceof Error ? error.message : 'Failed to add task',
         variant: 'destructive'
       });
-      // Close modal on error
-      setTaskModalOpen(false);
     } finally {
       // Don't reset AI thinking state here - let the event handlers handle it
       console.log('[DEBUG handleAddTask] Task addition function completed');
@@ -423,6 +418,7 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
           onEditTask={handleEditTask}
           onReorderTasks={reorderTasks}
           onTaskClick={handleTaskClick}
+          isAIThinking={isAIThinking}
         />
       </div>
 


### PR DESCRIPTION
This PR moves the AI thinking indicator from the task modal to the Q4 quadrant title and closes the task modal immediately after clicking 'Add Task' instead of waiting for AI analysis to complete. Changes include: 1. Removed AI thinking indicator from task modal title 2. Added subtle AI thinking indicator in Q4 quadrant header 3. Close task modal immediately after task submission 4. Reset AI thinking state after analysis completes